### PR TITLE
Fix refresh token command namespace

### DIFF
--- a/SmartShift.Application/Authentication/RefreshToken/RefreshTokenCommand.cs
+++ b/SmartShift.Application/Authentication/RefreshToken/RefreshTokenCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace SmartShift.Application.Authentication.Refresh;
+
+public class RefreshTokenCommand : IRequest<RefreshTokenResult>
+{
+    public string IpAddress { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/SmartShift.Application/Authentication/RefreshToken/RefreshTokenCommend.cs
+++ b/SmartShift.Application/Authentication/RefreshToken/RefreshTokenCommend.cs
@@ -1,9 +1,0 @@
-using MediatR;
-using SmartShift.Application.Authentication.Refresh;
-
-public class RefreshTokenCommand : IRequest<RefreshTokenResult>
-{
-    public string IpAddress { get; set; } = string.Empty; 
-     public string RefreshToken { get; set; } = string.Empty;
-     
-}


### PR DESCRIPTION
## Summary
- fix namespace for RefreshTokenCommand and rename file accordingly

## Testing
- `dotnet test SmartShift.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849c595d9e0832a9f4d4a6780f3910b